### PR TITLE
Debug ul error

### DIFF
--- a/HTMLToQPDF.Example/HTMLToQPDF.Example.csproj
+++ b/HTMLToQPDF.Example/HTMLToQPDF.Example.csproj
@@ -24,7 +24,7 @@
     </PackageReference>
     <PackageReference Include="HandyControls" Version="3.4.2" />
     <PackageReference Include="PropertyChanged.Fody" Version="4.0.4" />
-    <PackageReference Include="QuestPDF" Version="2022.9.0" />
+    <PackageReference Include="QuestPDF" Version="2023.12.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HTMLToQPDF.Example/Utilities/PDFCreator.cs
+++ b/HTMLToQPDF.Example/Utilities/PDFCreator.cs
@@ -9,6 +9,8 @@ namespace HTMLToQPDF.Example.Utilities
     {
         public static void Create(string html, string path, bool customStyles)
         {
+
+            QuestPDF.Settings.License = LicenseType.Community;
             Document.Create(container =>
             {
                 container.Page(page =>
@@ -17,10 +19,14 @@ namespace HTMLToQPDF.Example.Utilities
                     page.MarginHorizontal(0.5f, Unit.Centimetre);
                     page.MarginVertical(1f, Unit.Centimetre);
 
-                    page.DefaultTextStyle(TextStyle.Default
-                        .Fallback(y => y.FontFamily("MS Reference Sans Serif")
+                    page.DefaultTextStyle(TextStyle.Default.FontFamily("Arial").FontSize(8).Fallback(y => y.FontFamily("Segoe UI Emoji")));
+
+                  /* page.DefaultTextStyle(TextStyle.Default
+                    //    .Fallback(y => y.FontFamily("MS Reference Sans Serif")
                         .Fallback(y => y.FontFamily("Segoe UI Emoji")
-                        .Fallback(y => y.FontFamily("Microsoft YaHei")))));
+                      //  .Fallback(y => y.FontFamily("Microsoft YaHei")))
+                    ));
+                  */
 
                     page.Content().Column(col =>
                     {

--- a/HTMLToQPDF/Components/Tags/ImgComponent.cs
+++ b/HTMLToQPDF/Components/Tags/ImgComponent.cs
@@ -19,7 +19,7 @@ namespace HTMLQuestPDF.Components.Tags
         {
             var src = node.GetAttributeValue("src", "");
             var img = getImgBySrc(src) ?? Placeholders.Image(200, 100);
-            container.Image(img);
+            container.AlignCenter().Image(img).FitArea();
             
         }
     }

--- a/HTMLToQPDF/Components/Tags/ImgComponent.cs
+++ b/HTMLToQPDF/Components/Tags/ImgComponent.cs
@@ -19,7 +19,8 @@ namespace HTMLQuestPDF.Components.Tags
         {
             var src = node.GetAttributeValue("src", "");
             var img = getImgBySrc(src) ?? Placeholders.Image(200, 100);
-            container.Image(img, ImageScaling.FitArea);
+            container.Image(img);
+            
         }
     }
 }

--- a/HTMLToQPDF/HTMLToQPDF.csproj
+++ b/HTMLToQPDF/HTMLToQPDF.csproj
@@ -25,8 +25,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
-    <PackageReference Include="QuestPDF" Version="2022.9.0" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.59" />
+    <PackageReference Include="QuestPDF" Version="2023.12.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HTMLToQPDF/Utils/ImgUtils.cs
+++ b/HTMLToQPDF/Utils/ImgUtils.cs
@@ -4,6 +4,28 @@ namespace HTMLToQPDF.Utils
 {
     internal static class ImgUtils
     {
+
+        private static HttpClient _SingletonClient;
+
+        static ImgUtils() {
+
+            if (_SingletonClient == null)
+            {
+                _SingletonClient = new HttpClient();
+            }
+        }
+
+        /// <summary>
+        /// Call this manually at the end of the appliction life : Static classes don't auto Dispose.  
+        /// </summary>
+        public static void Dispose() {
+
+            if (_SingletonClient != null)
+            {
+                _SingletonClient.Dispose();
+            }
+        }
+        
         public static byte[]? GetImgBySrc(string src)
         {
             try
@@ -13,13 +35,33 @@ namespace HTMLToQPDF.Utils
                     var base64 = src.Substring(src.IndexOf("base64,") + "base64,".Length);
                     return Convert.FromBase64String(base64);
                 }
-                var webClient = new WebClient();
-                return webClient.DownloadData(src);
+
+                else {
+                    return Download(src).Result;
+                }
+
+           
             }
             catch
             {
                 return null;
             }
         }
+
+        private static Task<byte[]> Download(string src)
+        {
+
+            if (_SingletonClient != null)
+            {
+                Uri uri = new Uri(src);
+                return _SingletonClient.GetByteArrayAsync(uri);
+            }
+            else
+            {
+                // To prevent memory and IO socket Leaks HttpClient should be a singleton for life. 
+                throw new Exception("HttpClient not Available");
+            }
+        }
+     
     }
 }

--- a/HTMLToQPDF/Utils/UnitUtils.cs
+++ b/HTMLToQPDF/Utils/UnitUtils.cs
@@ -17,7 +17,7 @@ namespace HTMLToQPDF.Utils
                     Unit.Millimetre => 2.83464575f,
                     Unit.Feet => 864f,
                     Unit.Inch => 72f,
-                    Unit.Mill => 0.072f,
+                    Unit.Mil => 0.072f,
                     _ => throw new ArgumentOutOfRangeException("unit", unit, null),
                 };
             }


### PR DESCRIPTION
v1.1.0 fails when used with QuestPDF 2023.12.5 when encountering UL tags in the data.  
Investigation of the breaks suggested they are due to changes to ListsContainer Types in QuestPDF. 

On upgrade of QuestPDF to (2023.12.5) the following fixes were also applied.  

- Unit type has a name change for Mill to Mil
- Depreciated Image(img, scale) function in ImgComponent replaced with Image(img).FitArea() to achieve the equivalent Effect.  
- Added CommunityLicense to the Example project: 2023.12.5 requires a licence definition. 
- Added a AlignCenter()  to the ImgComponent to improve default output aesthetics. 

  